### PR TITLE
CHP-212 enabled alarm and added subscription endpoint for audit, and archive cloudwatch alarms

### DIFF
--- a/auditLogMover/serverless.yaml
+++ b/auditLogMover/serverless.yaml
@@ -3,7 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-service: audit-log-moverblu
+service: audit-log-mover
 
 custom:
   stage: ${opt:stage, self:provider.stage}

--- a/auditLogMover/serverless.yaml
+++ b/auditLogMover/serverless.yaml
@@ -3,7 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 #
 
-service: audit-log-mover
+service: audit-log-moverblu
 
 custom:
   stage: ${opt:stage, self:provider.stage}
@@ -79,109 +79,109 @@ stepFunctions:
             End: true
 
 resources:
-  - Conditions:
-      isAlarmSubscriptionEnabled: !Not [!Equals ['${self:custom.alarmSubscriptionEndpoint}', '']]
-  - Resources:
-      AuditLogsBucket:
-        Type: AWS::S3::Bucket
-        Properties:
-          BucketEncryption:
-            ServerSideEncryptionConfiguration:
-              - ServerSideEncryptionByDefault:
-                  SSEAlgorithm: AES256
-          PublicAccessBlockConfiguration:
-            BlockPublicAcls: true
-            BlockPublicPolicy: true
-            IgnorePublicAcls: true
-            RestrictPublicBuckets: true
+  Conditions:
+    isAlarmSubscriptionEnabled: !Not [!Equals ['${self:custom.alarmSubscriptionEndpoint}', '']]
+  Resources:
+    AuditLogsBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
 
-      AuditLogsBucketPolicy:
-        Type: AWS::S3::BucketPolicy
-        Properties:
-          Bucket: !Ref AuditLogsBucket
-          PolicyDocument:
-            Statement:
-              - Sid: AllowCWLogsGetBucketACL
-                Effect: Allow
-                Principal:
-                  Service:
-                    - !Join ['', ['logs.', !Ref AWS::Region, '.amazonaws.com']]
-                Action:
-                  - s3:GetBucketAcl
-                Resource:
-                  - !GetAtt AuditLogsBucket.Arn
-              - Sid: AllowCWLogsPutObject
-                Effect: Allow
-                Principal:
-                  Service:
-                    - !Join ['', ['logs.', !Ref AWS::Region, '.amazonaws.com']]
-                Action:
-                  - s3:PutObject
-                Resource:
-                  - !Join ['', [!GetAtt AuditLogsBucket.Arn, '/*']]
-                Condition:
-                  StringEquals:
-                    s3:x-amz-acl: 'bucket-owner-full-control'
+    AuditLogsBucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket: !Ref AuditLogsBucket
+        PolicyDocument:
+          Statement:
+            - Sid: AllowCWLogsGetBucketACL
+              Effect: Allow
+              Principal:
+                Service:
+                  - !Join ['', ['logs.', !Ref AWS::Region, '.amazonaws.com']]
+              Action:
+                - s3:GetBucketAcl
+              Resource:
+                - !GetAtt AuditLogsBucket.Arn
+            - Sid: AllowCWLogsPutObject
+              Effect: Allow
+              Principal:
+                Service:
+                  - !Join ['', ['logs.', !Ref AWS::Region, '.amazonaws.com']]
+              Action:
+                - s3:PutObject
+              Resource:
+                - !Join ['', [!GetAtt AuditLogsBucket.Arn, '/*']]
+              Condition:
+                StringEquals:
+                  s3:x-amz-acl: 'bucket-owner-full-control'
 
-      AuditLogMoverExportFailureAlarm:
-        Type: AWS::CloudWatch::Alarm
-        Metadata:
-          cfn_nag:
-            rules_to_suppress:
-              - id: W28
-                reason: 'We want to explicitly create an alarm name'
-        Properties:
-          AlarmDescription: Alarm when there is a exportCloudwatchLogs-Failure'
-          AlarmName: FhirSolution.${self:custom.stage}.AuditLogMover.ExportFailureAlarm
-          ActionsEnabled: !If [isAlarmSubscriptionEnabled, True, False]
-          ComparisonOperator: GreaterThanOrEqualToThreshold
-          EvaluationPeriods: 1
-          MetricName: exportCloudwatchLogs-Failure
-          Dimensions:
-            - Name: Stage
-              Value: ${opt:stage, self:provider.stage}
-          Namespace: Audit-Log-Mover
-          Period: 86400 #86400 = 24 hours
-          Statistic: Sum
-          Threshold: 1
-          TreatMissingData: notBreaching
-          Unit: Count
-          OKActions:
-            - ${self:custom.fhirWorksAlarmSNSTopicARN}
-          AlarmActions:
-            - ${self:custom.fhirWorksAlarmSNSTopicARN}
+    AuditLogMoverExportFailureAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Metadata:
+        cfn_nag:
+          rules_to_suppress:
+            - id: W28
+              reason: 'We want to explicitly create an alarm name'
+      Properties:
+        AlarmDescription: Alarm when there is a exportCloudwatchLogs-Failure'
+        AlarmName: FhirSolution.${self:custom.stage}.AuditLogMover.ExportFailureAlarm
+        ActionsEnabled: !If [isAlarmSubscriptionEnabled, True, False]
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        MetricName: exportCloudwatchLogs-Failure
+        Dimensions:
+          - Name: Stage
+            Value: ${opt:stage, self:provider.stage}
+        Namespace: Audit-Log-Mover
+        Period: 86400 #86400 = 24 hours
+        Statistic: Sum
+        Threshold: 1
+        TreatMissingData: notBreaching
+        Unit: Count
+        OKActions:
+          - ${self:custom.fhirWorksAlarmSNSTopicARN}
+        AlarmActions:
+          - ${self:custom.fhirWorksAlarmSNSTopicARN}
 
-      AuditLogMoverDeleteFailureAlarm:
-        Type: AWS::CloudWatch::Alarm
-        Metadata:
-          cfn_nag:
-            rules_to_suppress:
-              - id: W28
-                reason: 'We want to explicitly create an alarm name'
-        Properties:
-          AlarmDescription: Alarm when there is a deleteCloudwatchLogs-Failure'
-          AlarmName: FhirSolution.${self:custom.stage}.AuditLogMover.DeleteFailureAlarm
-          ActionsEnabled: !If [isAlarmSubscriptionEnabled, True, False]
-          ComparisonOperator: GreaterThanOrEqualToThreshold
-          EvaluationPeriods: 1
-          MetricName: deleteCloudwatchLogs-Failure
-          Dimensions:
-            - Name: Stage
-              Value: ${opt:stage, self:provider.stage}
-          Namespace: Audit-Log-Mover
-          Period: 86400
-          Statistic: Sum
-          Threshold: 1
-          TreatMissingData: notBreaching
-          Unit: Count
-          OKActions:
-            - ${self:custom.fhirWorksAlarmSNSTopicARN}
-          AlarmActions:
-            - ${self:custom.fhirWorksAlarmSNSTopicARN}
-  - Outputs:
-      AuditLogsBucket:
-        Description: Bucket used for storing past audit logs
-        Value: !Ref AuditLogsBucket
+    AuditLogMoverDeleteFailureAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Metadata:
+        cfn_nag:
+          rules_to_suppress:
+            - id: W28
+              reason: 'We want to explicitly create an alarm name'
+      Properties:
+        AlarmDescription: Alarm when there is a deleteCloudwatchLogs-Failure'
+        AlarmName: FhirSolution.${self:custom.stage}.AuditLogMover.DeleteFailureAlarm
+        ActionsEnabled: !If [isAlarmSubscriptionEnabled, True, False]
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        EvaluationPeriods: 1
+        MetricName: deleteCloudwatchLogs-Failure
+        Dimensions:
+          - Name: Stage
+            Value: ${opt:stage, self:provider.stage}
+        Namespace: Audit-Log-Mover
+        Period: 86400
+        Statistic: Sum
+        Threshold: 1
+        TreatMissingData: notBreaching
+        Unit: Count
+        OKActions:
+          - ${self:custom.fhirWorksAlarmSNSTopicARN}
+        AlarmActions:
+          - ${self:custom.fhirWorksAlarmSNSTopicARN}
+  Outputs:
+    AuditLogsBucket:
+      Description: Bucket used for storing past audit logs
+      Value: !Ref AuditLogsBucket
 
 plugins:
   - serverless-step-functions

--- a/auditLogMover/serverless.yaml
+++ b/auditLogMover/serverless.yaml
@@ -8,6 +8,8 @@ service: audit-log-mover
 custom:
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  alarmSubscriptionEndpoint: ${env:ALARM_SUBSCRIPTION_ENDPOINT, ''}
+  fhirWorksAlarmSNSTopicARN: !ImportValue FhirWorksAlarmSNSTopicARN
   bundle:
     packager: yarn
     linting: false # We use our own linter
@@ -77,99 +79,109 @@ stepFunctions:
             End: true
 
 resources:
-  Resources:
-    AuditLogsBucket:
-      Type: AWS::S3::Bucket
-      Properties:
-        BucketEncryption:
-          ServerSideEncryptionConfiguration:
-            - ServerSideEncryptionByDefault:
-                SSEAlgorithm: AES256
-        PublicAccessBlockConfiguration:
-          BlockPublicAcls: true
-          BlockPublicPolicy: true
-          IgnorePublicAcls: true
-          RestrictPublicBuckets: true
+  - Conditions:
+      isAlarmSubscriptionEnabled: !Not [!Equals ['${self:custom.alarmSubscriptionEndpoint}', '']]
+  - Resources:
+      AuditLogsBucket:
+        Type: AWS::S3::Bucket
+        Properties:
+          BucketEncryption:
+            ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: AES256
+          PublicAccessBlockConfiguration:
+            BlockPublicAcls: true
+            BlockPublicPolicy: true
+            IgnorePublicAcls: true
+            RestrictPublicBuckets: true
 
-    AuditLogsBucketPolicy:
-      Type: AWS::S3::BucketPolicy
-      Properties:
-        Bucket: !Ref AuditLogsBucket
-        PolicyDocument:
-          Statement:
-            - Sid: AllowCWLogsGetBucketACL
-              Effect: Allow
-              Principal:
-                Service:
-                  - !Join ['', ['logs.', !Ref AWS::Region, '.amazonaws.com']]
-              Action:
-                - s3:GetBucketAcl
-              Resource:
-                - !GetAtt AuditLogsBucket.Arn
-            - Sid: AllowCWLogsPutObject
-              Effect: Allow
-              Principal:
-                Service:
-                  - !Join ['', ['logs.', !Ref AWS::Region, '.amazonaws.com']]
-              Action:
-                - s3:PutObject
-              Resource:
-                - !Join ['', [!GetAtt AuditLogsBucket.Arn, '/*']]
-              Condition:
-                StringEquals:
-                  s3:x-amz-acl: 'bucket-owner-full-control'
+      AuditLogsBucketPolicy:
+        Type: AWS::S3::BucketPolicy
+        Properties:
+          Bucket: !Ref AuditLogsBucket
+          PolicyDocument:
+            Statement:
+              - Sid: AllowCWLogsGetBucketACL
+                Effect: Allow
+                Principal:
+                  Service:
+                    - !Join ['', ['logs.', !Ref AWS::Region, '.amazonaws.com']]
+                Action:
+                  - s3:GetBucketAcl
+                Resource:
+                  - !GetAtt AuditLogsBucket.Arn
+              - Sid: AllowCWLogsPutObject
+                Effect: Allow
+                Principal:
+                  Service:
+                    - !Join ['', ['logs.', !Ref AWS::Region, '.amazonaws.com']]
+                Action:
+                  - s3:PutObject
+                Resource:
+                  - !Join ['', [!GetAtt AuditLogsBucket.Arn, '/*']]
+                Condition:
+                  StringEquals:
+                    s3:x-amz-acl: 'bucket-owner-full-control'
 
-    AuditLogMoverExportFailureAlarm:
-      Type: AWS::CloudWatch::Alarm
-      Metadata:
-        cfn_nag:
-          rules_to_suppress:
-            - id: W28
-              reason: 'We want to explicitly create an alarm name'
-      Properties:
-        AlarmDescription: Alarm when there is a exportCloudwatchLogs-Failure'
-        AlarmName: FhirSolution.${self:custom.stage}.AuditLogMover.ExportFailureAlarm
-        ActionsEnabled: False
-        ComparisonOperator: GreaterThanOrEqualToThreshold
-        EvaluationPeriods: 1
-        MetricName: exportCloudwatchLogs-Failure
-        Dimensions:
-          - Name: Stage
-            Value: ${opt:stage, self:provider.stage}
-        Namespace: Audit-Log-Mover
-        Period: 86400 #86400 = 24 hours
-        Statistic: Sum
-        Threshold: 1
-        TreatMissingData: notBreaching
-        Unit: Count
+      AuditLogMoverExportFailureAlarm:
+        Type: AWS::CloudWatch::Alarm
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: W28
+                reason: 'We want to explicitly create an alarm name'
+        Properties:
+          AlarmDescription: Alarm when there is a exportCloudwatchLogs-Failure'
+          AlarmName: FhirSolution.${self:custom.stage}.AuditLogMover.ExportFailureAlarm
+          ActionsEnabled: !If [isAlarmSubscriptionEnabled, True, False]
+          ComparisonOperator: GreaterThanOrEqualToThreshold
+          EvaluationPeriods: 1
+          MetricName: exportCloudwatchLogs-Failure
+          Dimensions:
+            - Name: Stage
+              Value: ${opt:stage, self:provider.stage}
+          Namespace: Audit-Log-Mover
+          Period: 86400 #86400 = 24 hours
+          Statistic: Sum
+          Threshold: 1
+          TreatMissingData: notBreaching
+          Unit: Count
+          OKActions:
+            - ${self:custom.fhirWorksAlarmSNSTopicARN}
+          AlarmActions:
+            - ${self:custom.fhirWorksAlarmSNSTopicARN}
 
-    AuditLogMoverDeleteFailureAlarm:
-      Type: AWS::CloudWatch::Alarm
-      Metadata:
-        cfn_nag:
-          rules_to_suppress:
-            - id: W28
-              reason: 'We want to explicitly create an alarm name'
-      Properties:
-        AlarmDescription: Alarm when there is a deleteCloudwatchLogs-Failure'
-        AlarmName: FhirSolution.${self:custom.stage}.AuditLogMover.DeleteFailureAlarm
-        ActionsEnabled: False
-        ComparisonOperator: GreaterThanOrEqualToThreshold
-        EvaluationPeriods: 1
-        MetricName: deleteCloudwatchLogs-Failure
-        Dimensions:
-          - Name: Stage
-            Value: ${opt:stage, self:provider.stage}
-        Namespace: Audit-Log-Mover
-        Period: 86400
-        Statistic: Sum
-        Threshold: 1
-        TreatMissingData: notBreaching
-        Unit: Count
-  Outputs:
-    AuditLogsBucket:
-      Description: Bucket used for storing past audit logs
-      Value: !Ref AuditLogsBucket
+      AuditLogMoverDeleteFailureAlarm:
+        Type: AWS::CloudWatch::Alarm
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: W28
+                reason: 'We want to explicitly create an alarm name'
+        Properties:
+          AlarmDescription: Alarm when there is a deleteCloudwatchLogs-Failure'
+          AlarmName: FhirSolution.${self:custom.stage}.AuditLogMover.DeleteFailureAlarm
+          ActionsEnabled: !If [isAlarmSubscriptionEnabled, True, False]
+          ComparisonOperator: GreaterThanOrEqualToThreshold
+          EvaluationPeriods: 1
+          MetricName: deleteCloudwatchLogs-Failure
+          Dimensions:
+            - Name: Stage
+              Value: ${opt:stage, self:provider.stage}
+          Namespace: Audit-Log-Mover
+          Period: 86400
+          Statistic: Sum
+          Threshold: 1
+          TreatMissingData: notBreaching
+          Unit: Count
+          OKActions:
+            - ${self:custom.fhirWorksAlarmSNSTopicARN}
+          AlarmActions:
+            - ${self:custom.fhirWorksAlarmSNSTopicARN}
+  - Outputs:
+      AuditLogsBucket:
+        Description: Bucket used for storing past audit logs
+        Value: !Ref AuditLogsBucket
 
 plugins:
   - serverless-step-functions

--- a/cloudformation/alarms.yaml
+++ b/cloudformation/alarms.yaml
@@ -732,7 +732,7 @@ Resources:
     Properties:
       AlarmDescription: Alarm when the ArchiveService Lambda function errors is more than 1 unit for 15 minutes out of the past 25 minutes.
       AlarmName: !Join ['.', [FhirSolution, !Ref Stage, High, ArchiveServiceLambdaErrorAlarm]]
-      ActionsEnabled: False
+      ActionsEnabled: !If [isAlarmSubscriptionEnabled, True, False]
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 5
       DatapointsToAlarm: 3
@@ -746,12 +746,16 @@ Resources:
       Threshold: 1
       TreatMissingData: notBreaching
       Unit: Count
+      OKActions:
+        - !Ref FhirWorksAlarmSNSTopic
+      AlarmActions:
+        - !Ref FhirWorksAlarmSNSTopic
   ArchiveDeliveryStreamCountAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmDescription: Alarm when the archive firehose delivery stream putRecord(s) success count is 2 standard deviations lower in 1 day.
       AlarmName: !Join ['.', [FhirSolution, !Ref Stage, Low, ArchiveDeliveryStreamCountAlarm]]
-      ActionsEnabled: False
+      ActionsEnabled: !If [isAlarmSubscriptionEnabled, True, False]
       ComparisonOperator: LessThanLowerThreshold
       EvaluationPeriods: 3
       DatapointsToAlarm: 1
@@ -773,3 +777,7 @@ Resources:
           Expression: ANOMALY_DETECTION_BAND(m1, 2)
           Label: PutRecords.Success (expected)
           ReturnData: true
+      OKActions:
+        - !Ref FhirWorksAlarmSNSTopic
+      AlarmActions:
+        - !Ref FhirWorksAlarmSNSTopic

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -527,6 +527,7 @@ echo ""
 if `YesOrNo "Would you like to set the server to archive logs older than 7 days?"`; then
     cd ${PACKAGE_ROOT}/auditLogMover
     yarn install --frozen-lockfile
+    ALARM_SUBSCRIPTION_ENDPOINT=$alarmSubscriptionEndpoint \
     yarn run serverless-deploy --region $region --stage $stage
     cd ${PACKAGE_ROOT}
     echo -e "\n\nSuccess."

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -964,11 +964,6 @@ resources:
         Value: !Ref FhirWorksAlarmSNSTopic
         Export:
           Name: FhirWorksAlarmSNSTopicARN
-      FhirWorksAlarmSNSTopicSubscription:
-        Description: SNS topic for fhirworks alarms
-        Value: !Ref FhirWorksAlarmSNSTopicSubscription
-        Export:
-          Name: FhirWorksAlarmSNSTopicSubscriptionARN
       ResourceDynamoDBTableV2Arn:
         Description: DynamoDB table for storing non-Binary resources
         Value: !GetAtt ResourceDynamoDBTableV2.Arn

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -959,13 +959,16 @@ resources:
       FHIRBinaryBucket:
         Description: S3 Bucket for storing Binary Objects
         Value: !Ref FHIRBinaryBucket
-
       FhirWorksAlarmSNSTopic:
         Description: SNS topic for fhirworks alarms
         Value: !Ref FhirWorksAlarmSNSTopic
         Export:
           Name: FhirWorksAlarmSNSTopicARN
-
+      FhirWorksAlarmSNSTopicSubscription:
+        Description: SNS topic for fhirworks alarms
+        Value: !Ref FhirWorksAlarmSNSTopicSubscription
+        Export:
+          Name: FhirWorksAlarmSNSTopicSubscriptionARN
       ResourceDynamoDBTableV2Arn:
         Description: DynamoDB table for storing non-Binary resources
         Value: !GetAtt ResourceDynamoDBTableV2.Arn

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -959,6 +959,13 @@ resources:
       FHIRBinaryBucket:
         Description: S3 Bucket for storing Binary Objects
         Value: !Ref FHIRBinaryBucket
+
+      FhirWorksAlarmSNSTopic:
+        Description: SNS topic for fhirworks alarms
+        Value: !Ref FhirWorksAlarmSNSTopic
+        Export:
+          Name: FhirWorksAlarmSNSTopicARN
+
       ResourceDynamoDBTableV2Arn:
         Description: DynamoDB table for storing non-Binary resources
         Value: !GetAtt ResourceDynamoDBTableV2.Arn


### PR DESCRIPTION
Description of changes:
CHP-212 enabled alarm and added subscription endpoint for audit, and archive cloudwatch alarms

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
